### PR TITLE
Resize buffers to allow maximum string size

### DIFF
--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -93,7 +93,7 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
 }
 
 static void fans_top_speed_inc() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[0].slider);
 
     if (value < MAX_FAN_TOP)
@@ -111,7 +111,7 @@ static void fans_top_speed_inc() {
 }
 
 static void fans_top_speed_dec() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[0].slider);
 
     if (value > MIN_FAN_TOP)
@@ -128,7 +128,7 @@ static void fans_top_speed_dec() {
 }
 
 static void fans_side_speed_inc() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[1].slider);
 
     if (value < MAX_FAN_SIDE)
@@ -146,7 +146,7 @@ static void fans_side_speed_inc() {
 }
 
 static void fans_side_speed_dec() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[1].slider);
 
     if (value > MIN_FAN_SIDE)

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -233,7 +233,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
 
 static void ht_angle_inc(void) {
     int32_t value = 0;
-    char buf[5];
+    char buf[12];
 
     value = lv_slider_get_value(slider_group.slider);
     if (value < 360)
@@ -251,7 +251,7 @@ static void ht_angle_inc(void) {
 
 static void ht_angle_dec(void) {
     int32_t value = 0;
-    char buf[5];
+    char buf[12];
 
     value = lv_slider_get_value(slider_group.slider);
     if (value > 0)

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -846,7 +846,7 @@ static void page_wifi_on_roller(uint8_t key) {
                 value += 1;
             }
         }
-        char buf[3];
+        char buf[12];
         sprintf(buf, "%d", value + 1);
         lv_label_set_text(page_wifi.page_2.rf_channel.input.label, buf);
         lv_slider_set_value(page_wifi.page_2.rf_channel.input.slider, value, LV_ANIM_OFF);


### PR DESCRIPTION
I compile the emulator locally with gcc-14 and it outputs warnings for some of the buffers used to hold numerical values (see example screenshot below).

These changes should not do any harm but use more of the stack memory while calling the changed methods, but it should be ok imho.